### PR TITLE
build: use mongodb 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Authors
 #  Vassilis Vassiliadis
 
-FROM quay.io/mongodb/mongodb-community-server:6.0-ubi9 AS base
+FROM quay.io/mongodb/mongodb-community-server:7.0-ubi9 AS base
 
 USER root
 COPY mongod.conf /etc/mongod.conf


### PR DESCRIPTION
## Context

MongoDB 6 went EOL on July 31st and is not being maintained anymore: https://www.mongodb.com/legal/support-policy/lifecycles
This PR updates to version 7.

## Change list

- Use MongoDB 7

## Checklist

Ensure your PR meets the following requirements:

- [ ] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
